### PR TITLE
Fixed detection of x64 vs x86 dependencies

### DIFF
--- a/thirdparty/npcap/Modules/Findnpcap.cmake
+++ b/thirdparty/npcap/Modules/Findnpcap.cmake
@@ -38,7 +38,7 @@ find_path(npcap_INCLUDE_DIR
 )
 
 # Lib dir
-if(("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64") OR ("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)"))
+if("${CMAKE_SIZEOF_VOID_P}" EQUAL 8)
     # Find 64-bit libraries
     find_path (npcap_LIB_DIR
         NAMES wpcap.lib

--- a/thirdparty/pcapplusplus/Modules/Findpcapplusplus.cmake
+++ b/thirdparty/pcapplusplus/Modules/Findpcapplusplus.cmake
@@ -41,7 +41,7 @@ find_path(pcapplusplus_INCLUDE_DIR
 )
 
 # Lib dir
-if(("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64") OR ("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)"))
+if("${CMAKE_SIZEOF_VOID_P}" EQUAL 8)
     # Find 64-bit libraries
     find_path (pcapplusplus_LIB_DIR
         NAMES "Release/Pcap++.lib"


### PR DESCRIPTION
before, the CMAKE_GENERATOR_PLATFORM was used, which may not be set at all, if the default setting is being used. Now the proper CMAKE_SIZEOF_VOID_P variable is used.