### PR TITLE
[CMake / build-in deps] Fixed Pcap++ build (Warnings-as-errors)

### DIFF
--- a/thirdparty/pcapplusplus/pcapplusplus_make_available.cmake
+++ b/thirdparty/pcapplusplus/pcapplusplus_make_available.cmake
@@ -10,8 +10,44 @@ set(PCAPPP_INSTALL ON)
 message(STATUS "Fetching Pcap++...")
 FetchContent_MakeAvailable(pcapplusplus)
 
+# Add alias targets for PcapPlusPlus
+
+if(NOT TARGET PcapPlusPlus::Common++)
+    add_library(PcapPlusPlus::Common++ ALIAS Common++)
+endif()
+
 if(NOT TARGET PcapPlusPlus::Pcap++)
     add_library(PcapPlusPlus::Pcap++ ALIAS Pcap++)
 endif()
+
+if(NOT TARGET PcapPlusPlus::Packet++)
+    add_library(PcapPlusPlus::Packet++ ALIAS Packet++)
+endif()
+
+# Disable warnings as errors for Pcap++. They have a lot of warnings but treat
+# them as errors, which breaks our build, if the warnings are enabled.
+set_property(TARGET Common++ PROPERTY COMPILE_WARNING_AS_ERROR OFF)
+set_property(TARGET Pcap++   PROPERTY COMPILE_WARNING_AS_ERROR OFF)
+set_property(TARGET Packet++ PROPERTY COMPILE_WARNING_AS_ERROR OFF)
+
+# Also, disable the compiler warnings for those targets. It's not our code, so
+# we don't want to see their warnings.
+target_compile_options(Common++ PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+            -w>
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /W0>)
+
+target_compile_options(Pcap++ PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+            -w>
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /W0>)
+
+target_compile_options(Packet++ PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+            -w>
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /W0>)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules/")


### PR DESCRIPTION
- Disabled Pcap++ / Common++ / Packet++ treat-warnings-as-errors (they have many warnings if any other dependency enables them AND they treat them as errors)
- Disabled compiler warnings for those 3 targets entirely
- Added proper alias targets