### PR TITLE
[CMake]: Adapted Pcap++ Make Available script to the new v25.05

### DIFF
--- a/thirdparty/pcapplusplus/pcapplusplus_make_available.cmake
+++ b/thirdparty/pcapplusplus/pcapplusplus_make_available.cmake
@@ -5,7 +5,11 @@ FetchContent_Declare(pcapplusplus
     DOWNLOAD_EXTRACT_TIMESTAMP FALSE
     )
 
-set(PCAPPP_INSTALL ON)
+# 2025-05-15: The PCAPPP_INSTALL must be a cache variable, as
+# Pacp++ v25.05 uses CMake 3.12 policies. These old CMake versions
+#prevented setting options from normal variables.
+#https://cmake.org/cmake/help/latest/policy/CMP0077.html
+set(PCAPPP_INSTALL ON CACHE BOOL "" FORCE) 
 
 message(STATUS "Fetching Pcap++...")
 FetchContent_MakeAvailable(pcapplusplus)


### PR DESCRIPTION
They re-tagged their v25.05 tag. The old tag from 2025-05-14 used CMake 3.14, while the new tag from 2025-05-15 uses CMake 3.12. This made it necessary to set the PCAPPP_INSTALL option as a cache variable (See CMake Policy CMP0077)